### PR TITLE
Add huggingface node pool toleration

### DIFF
--- a/huggingface_dag.py
+++ b/huggingface_dag.py
@@ -25,6 +25,7 @@ from dataloader.airflow_utils.defaults import (
     get_post_success,
 )
 from dataloader.scripts.populate_documentation import update_table_descriptions
+from kubernetes.client import models as k8s
 
 bucket = DATA_BUCKET
 production_dataset = "huggingface"
@@ -92,7 +93,9 @@ with dag:
                     }]
                 }
             }
-        }
+        },
+        tolerations=[k8s.V1Toleration(key="huggingface", operator="Equal", value="true")],
+        annotations={"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
     )
 
     # clean the huggingface data
@@ -130,7 +133,9 @@ with dag:
                     }]
                 }
             }
-        }
+        },
+        tolerations=[k8s.V1Toleration(key="huggingface", operator="Equal", value="true")],
+        annotations={"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
     )
 
     # load the cleaned data into one big table
@@ -193,7 +198,9 @@ with dag:
                     }]
                 }
             }
-        }
+        },
+        tolerations=[k8s.V1Toleration(key="huggingface", operator="Equal", value="true")],
+        annotations={"cluster-autoscaler.kubernetes.io/safe-to-evict": "true"},
     )
 
     # load the leaderboard data


### PR DESCRIPTION
I'm working to prevent GKE from scheduling its own operations on more expensive node pools by adding taints to those pools, and tolerations to the relevant GKEStartPodOperators (see also https://cloud.google.com/kubernetes-engine/distributed-cloud/vmware/docs/how-to/node-taints). I'm also adding the safe-to-evict annotation in response to messages like this

<img width="581" alt="Screenshot 2024-08-21 at 10 52 49 AM" src="https://github.com/user-attachments/assets/6abf2507-2f76-482b-95b7-cb024e068259">
